### PR TITLE
Fixing Docker: Changing to stable python branch

### DIFF
--- a/LIMS_IMAGE/web/Dockerfile
+++ b/LIMS_IMAGE/web/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:latest
+FROM python:3.7
 ENV PYTHONBUFFEREED=1
 WORKDIR /src
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
Steps To Recreate:
1. Using this branch run `docker-compose up --build`
2. Go to `http://localhost:8000/`
3. Confirm you can log in with 'root' and 'Lab_rats2021'

Suspected cause: there was a python update and it broke django. I changed to a version set version of python instead of the latest. This way we don't have issues if the python image updates, and we don't know. If we see an update we can attempt it and see if it works or not, but they might not be stable with django just yet.