### PR TITLE
CI to only run on pull requests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,7 +1,10 @@
 name: LIMS-CI-Container
 
 on:
-  [push, pull_request]
+  pull_request:
+    branches:
+      - development
+      - main
 
 jobs:
 


### PR DESCRIPTION
To avoid clogging our actions queue and prevent cloud server costs, this commit will set the CI action to only run when a pull request is created, instead of on every push.