### PR TITLE
Distribute samples

### DIFF
--- a/LIMS_IMAGE/web/laboratory/urls.py
+++ b/LIMS_IMAGE/web/laboratory/urls.py
@@ -13,6 +13,7 @@ urlpatterns = [
     path('sample_list/', views.sample_list,
          name='lab_sample_list'),  # List of all samples + search bar
     path('distribution/', views.ready_for_distribution, name='distribution'),
+    path('distribute_sample/<sample_id>', views.create_lab_sample, name='distribute_sample'),
     path('order_list/', views.order_list,
          name='order_list'),  # List of all samples + search bar
     path("barcode/<sample_id>/", views.view_barcode, name="view_barcode"),

--- a/LIMS_IMAGE/web/laboratory/views.py
+++ b/LIMS_IMAGE/web/laboratory/views.py
@@ -51,14 +51,14 @@ def create_lab_sample(request, sample_id):
     if request.method == 'POST': # Form callback with post
         results = request.POST.items()
         for result in results:
-            if result[0] != 'csrfmiddlewaretoken' and not LabSample.objects.filter(sample=sample_id, location__name=result[0]):
-                print('Result: ' + str(result), flush=True)
-                print('Location: ' + str(Location.objects.filter(name=result[0]).first()))
-                #ls = LabSample(
-                #    sample=Sample.objects.filter(id=sample_id).first(),
-                #    location=Location.objects.filter(name=result[0]).first()
-                #    )
-                #print('Created new lab sample: ' + str(ls))
+            if result[0] != 'csrfmiddlewaretoken' and not LabSample.objects.filter(sample=sample_id, location__code=result[1]):
+                #print('Result: ' + str(result), flush=True)
+                #print('Location: ' + str(Location.objects.filter(code=result[1]).first()), flush=True)
+                ls = LabSample(
+                    sample=Sample.objects.filter(id=sample_id).first(),
+                    location=Location.objects.filter(code=result[1]).first()
+                    ).save()
+                #print('Created new lab sample: ' + str(ls), flush=True)
 
     context = {'sample': sample, 'locations': locations}
     return render(request, 'laboratory/distribute_sample.html', context)

--- a/LIMS_IMAGE/web/laboratory/views.py
+++ b/LIMS_IMAGE/web/laboratory/views.py
@@ -48,8 +48,10 @@ def create_lab_sample(request, sample_id):
     sample = Sample.objects.filter(id=sample_id).first()
 
     # Form
+    message = ''
     if request.method == 'POST': # Form callback with post
         results = request.POST.items()
+        added = ''
         for result in results:
             if result[0] != 'csrfmiddlewaretoken' and not LabSample.objects.filter(sample=sample_id, location__code=result[1]):
                 #print('Result: ' + str(result), flush=True)
@@ -57,10 +59,18 @@ def create_lab_sample(request, sample_id):
                 ls = LabSample(
                     sample=Sample.objects.filter(id=sample_id).first(),
                     location=Location.objects.filter(code=result[1]).first()
-                    ).save()
+                    )
+                added += str(ls) + ', '
+                ls.save()
+                #print(added, flush=True)
                 #print('Created new lab sample: ' + str(ls), flush=True)
+        if added != '':
+            message = 'Added lab samples: ' + added[:-2]
+            print('Message: ' + message, flush=True)
+            context = {'sample': sample, 'locations': locations, 'message': message}
+            return render(request, 'laboratory/distribute_sample.html', context)
 
-    context = {'sample': sample, 'locations': locations}
+    context = {'sample': sample, 'locations': locations, 'message': message}
     return render(request, 'laboratory/distribute_sample.html', context)
 
 

--- a/LIMS_IMAGE/web/laboratory/views.py
+++ b/LIMS_IMAGE/web/laboratory/views.py
@@ -1,6 +1,6 @@
 from django.shortcuts import render, redirect
 from laboratoryOrders.models import SampleInspection
-from laboratoryOrders.forms import InspectionForm, DistributionForm
+from laboratoryOrders.forms import InspectionForm
 from accounts.models import Client, LabWorker
 from .forms import ImageForm
 from src.barcoder import Barcoder

--- a/LIMS_IMAGE/web/laboratoryOrders/forms.py
+++ b/LIMS_IMAGE/web/laboratoryOrders/forms.py
@@ -6,9 +6,3 @@ class InspectionForm(forms.ModelForm):
     class Meta:
         model = SampleInspection
         fields = ('received_quantity', 'package_intact', 'material_intact', 'inspection_pass')
-
-class DistributionForm(forms.ModelForm):
-    """Form for the sample distribution"""
-    class Meta:
-        model = LabSample
-        fields = ['location']

--- a/LIMS_IMAGE/web/laboratoryOrders/forms.py
+++ b/LIMS_IMAGE/web/laboratoryOrders/forms.py
@@ -1,8 +1,14 @@
 from django import forms
-from .models import SampleInspection
+from .models import SampleInspection, LabSample
 
 class InspectionForm(forms.ModelForm):
     """Form for the image model"""
     class Meta:
         model = SampleInspection
         fields = ('received_quantity', 'package_intact', 'material_intact', 'inspection_pass')
+
+class DistributionForm(forms.ModelForm):
+    """Form for the sample distribution"""
+    class Meta:
+        model = LabSample
+        fields = ['location']

--- a/LIMS_IMAGE/web/templates/laboratory/distribute_sample.html
+++ b/LIMS_IMAGE/web/templates/laboratory/distribute_sample.html
@@ -23,12 +23,7 @@
     </form>
 
       
-      {% if complete and message %}
-        <h3>{{ message }}</h3>
-      {% endif %}
-      {% if complete and not message %}
-        <h3>Successfully Updated</h3>
-      {% endif %}
+    <p>{{ message }}</p>
   {% endblock %}
   </div>
 </body>

--- a/LIMS_IMAGE/web/templates/laboratory/distribute_sample.html
+++ b/LIMS_IMAGE/web/templates/laboratory/distribute_sample.html
@@ -1,0 +1,34 @@
+{% extends 'base.html' %}
+<!-- Not having this here makes the interpreter mad -->
+{% block title %}Distribute Sample{% endblock %}
+<!-- Not having this here makes the interpreter mad -->
+<body>
+  {% block content%}
+  <div class="container">
+    <h1>Distribute Sample</h1>
+
+    <p>ID: {{ sample.user_side_id }}</p>
+    <p>Type: {{ sample.sample_type }}</p>
+    <p>Form: {{ sample.sample_form }}</p>
+
+    <form method="post">
+        <p><strong>Select lab locations to create lab samples for:</strong></p>
+        {% csrf_token %}
+        {% for location in locations %}
+          <input type='checkbox' value={{ location.code }} id='{{ location.code }}' name={{ location.name }}></input>
+          <label for='{{location.code}}'>{{location.name}}</label><br>
+        {% endfor %}
+        <br>
+        <button type="submit">Create Lab Sample(s)</button>
+    </form>
+
+      
+      {% if complete and message %}
+        <h3>{{ message }}</h3>
+      {% endif %}
+      {% if complete and not message %}
+        <h3>Successfully Updated</h3>
+      {% endif %}
+  {% endblock %}
+  </div>
+</body>

--- a/LIMS_IMAGE/web/templates/laboratory/distribution.html
+++ b/LIMS_IMAGE/web/templates/laboratory/distribution.html
@@ -2,7 +2,7 @@
 {% load static %}
 {% load bootstrap5 %} 
 {% load admin_urls %}
-{% block title %}Sample List{% endblock %}
+{% block title %}Distribution{% endblock %}
 {% block additionalStyles %}
 <link rel="stylesheet" href="{% static 'laboratory/css/distribution.css' %}" />
 <script src="{% static 'laboratory/js/sample_list_search.js' %}" defer></script>
@@ -22,9 +22,9 @@
             <th>Test Code (Appendix-C)</th>
             <th>SOP No.</th>
             <th>Lab Personnel</th>
+            <th></th>
           </tr>
           {% for sample in samples %}
-          {% comment %} samples = context = {'samples': sample_list} {% endcomment %}
             <tr>
               <td> <a href="{% url 'laboratory:view_sample' sample.0.id %}">{{ sample.1 }}</a></td>
               <td>{{ sample.0.sample_type }}</td>
@@ -32,31 +32,12 @@
               <td></td>
               <td>{{ sample.0.sop_number }}</td>
               <td> {{ sample.0.lab_personel }}</td>
+              <td><a href="{% url 'laboratory:distribute_sample' sample.0.id %}">Distribute Sample</a></td>
             </tr>
           {% endfor %}
         </table>
 
       {% endif %}
-      {% comment %} <div class="search-wrapper">
-        <h1>Sample List</h1> 
-        <button class="btn btn-success my-4" onclick="location.href='{% url 'admin:laboratoryOrders_sample_add' %}'">Add Sample</button>
-        <input type="search" id="search" class="form-control" placeholder="Search" aria-label="Search">
-        {% for sample in samples %}
-        <ul class="list-group">
-            <li class="list-group-item bg-light">
-                <div class="d-flex justify-content-between">
-                    <h5 class="mb-1">Sample: {{ sample }}</h5>
-                    
-                  </div>
-                  <p class="mb-1">Sample Type: {{ sample.sample_type }}</p>
-                  <p class="mb-1">Sample Form: {{ sample.sample_form }}</p>
-                  <p class="mb-1">SOP number: {{ sample.sop_number }}</p>
-                  <small>Assigned worker: {{ sample.lab_personel }}</small><br>
-                  <small>Last updated: {{ sample.updated_at }}</small><br>
-                  <a href="{% url 'admin:laboratoryOrders_sample_change' sample.id %}"><small>Update info here</small></a>
-            </li>
-        </ul>
-        {% endfor %} {% endcomment %}
     <div>
     {% endblock content %}
 </body>


### PR DESCRIPTION
Sample distribution functionality!
The distribution page will now have a link to create lab samples for any items in the table (items appear in the table if they have passed inspection, but have no lab samples).
The form allows lab employees to select which lab locations they would like to distribute the sample to. A labSample instance will be created for each entry selected, and a message will appear explaining that the lab samples were created successfully. If all went well, then the sample should no longer appear in the distribution page and the new lab samples should appear in the admin dashboard.