### PR TITLE
Email Notification Setup

### DIFF
--- a/LIMS_IMAGE/web/laboratory/views.py
+++ b/LIMS_IMAGE/web/laboratory/views.py
@@ -169,7 +169,7 @@ def validate_sample(request, sample_id):
                 f"""
                 Dear {inspection.sample.order().account_number.user.first_name},
 
-                Your {inspection.sample.sample_type} sample ID {inspection.sample.id} order #{inspection.sample.order().order_number} has been inspected by {inspection.inspector}.
+                Your {inspection.sample.sample_type} sample ID {inspection.sample.id} order #{inspection.sample.order().order_number} has been inspected by {inspection.inspector.first_name}.
                 Results:
                     received quantity: {inspection.received_quantity}
                     Package intact: {inspection.package_intact}

--- a/LIMS_IMAGE/web/laboratory/views.py
+++ b/LIMS_IMAGE/web/laboratory/views.py
@@ -167,7 +167,7 @@ def validate_sample(request, sample_id):
             send_mail(
                 'Inspection Received',
                 f"""
-                Dear {inspection.sample.order().account_number},
+                Dear {inspection.sample.order().account_number.user.first_name},
 
                 Your {inspection.sample.sample_type} sample ID {inspection.sample.id} order #{inspection.sample.order().order_number} has been inspected by {inspection.inspector}.
                 Results:
@@ -179,7 +179,7 @@ def validate_sample(request, sample_id):
                 Please do not reply to this email.
                 """,
                 'lims0.system@gmail.com',
-                ['wilmc17@gmail.com'],
+                [inspection.sample.order().account_number.user.email],
                 fail_silently=False,
             )
 

--- a/LIMS_IMAGE/web/laboratory/views.py
+++ b/LIMS_IMAGE/web/laboratory/views.py
@@ -165,7 +165,7 @@ def validate_sample(request, sample_id):
 
             # Send email to client
             send_mail(
-                'Inspection Received',
+                'Inspection Received', # Subject
                 f"""
                 Dear {inspection.sample.order().account_number.user.first_name},
 
@@ -177,10 +177,10 @@ def validate_sample(request, sample_id):
                     Inspection pass: {inspection.inspection_pass}
 
                 Please do not reply to this email.
-                """,
-                'lims0.system@gmail.com',
-                [inspection.sample.order().account_number.user.email],
-                fail_silently=False,
+                """, # Body
+                'lims0.system@gmail.com', # From
+                [inspection.sample.order().account_number.user.email], # To
+                fail_silently=False, # Raise exception if failure
             )
 
         return view_sample(request, sample_id)

--- a/LIMS_IMAGE/web/orders/models.py
+++ b/LIMS_IMAGE/web/orders/models.py
@@ -41,7 +41,9 @@ class Order(models.Model):
     
     def next_order_number(account):
         orders = Order.objects.filter(account_number = account).order_by('order_number')
-        return orders.last().order_number + 1
+        if orders.last() != None:
+            return orders.last().order_number + 1
+        else: return 1
 
 
 class Invoice(models.Model):

--- a/LIMS_IMAGE/web/src/settings.py
+++ b/LIMS_IMAGE/web/src/settings.py
@@ -149,3 +149,11 @@ MEDIA_URL = '/uploads/'
 # Path where media is stored
 MEDIA_ROOT = (BASE_DIR)
 
+# Email
+EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
+EMAIL_HOST = 'smtp.gmail.com'
+EMAIL_HOST_USER = 'lims0.system@gmail.com'
+EMAIL_HOST_PASSWORD = os.environ.get('EMAIL_PASSWORD')
+EMAIL_PORT = 587
+EMAIL_USE_TLS = True
+DEFAULT_FROM_EMAIL = 'lims0.system@gmail.com'

--- a/LIMS_IMAGE/web/templates/laboratory/view_lab_sample.html
+++ b/LIMS_IMAGE/web/templates/laboratory/view_lab_sample.html
@@ -11,7 +11,7 @@
     <p>Type: {{ sample.sample_type }}</p>
     <p>Form: {{ sample.sample_form }}</p>
     <p>SOP Number: {{ sample.sop_number }}</p>
-    <p>Lab Personal In Change of Sample: {{ sample.lab_personel }}</p>
+    <p>Lab Personnel In Change of Sample: {{ sample.lab_personel }}</p>
     <p>Location: {{ lab_sample.location }}</p>
     <img src="{{ barcode_file_path }}" alt="connect" style="max-height:300px"><br>
 

--- a/README.md
+++ b/README.md
@@ -9,10 +9,12 @@ Repository for UBC Capstone project 2021/2022, group LIMS 0
   - [Accessing Admin Site](#accessing-the-admin-site)
   - [Making Migrations](#making-migrations)
   - [Testing](#testing)
+  - [Email Setup](#email-setup)
 - [Database Instructions](#database-instructions)
   - [Using Docker Image to Run Web Server](#using-docker-image-to-run-web-server)
   - [Enter the Docker Image](#enter-the-docker-image)
   - [Exporting a Database Backup](#exporting-a-database-backup)
+- [Test Guide](LIMS_IMAGE/web/tests/README.md)
 - [Style Guide](LIMS%20Style%20Guide.pdf)
 - [Meeting Notes](Notes/)
 
@@ -54,6 +56,7 @@ More Info in [LIMS.pdf](LIMS.pdf)
 ```
 SECRET_KEY=fake_key
 DJANGO_SETTINGS_MODULE=src.settings
+EMAIL_PASSWORD=email_app_password
 
 MSSQL_HOST=fake_mssql_host_name
 DB_USER=fake_user
@@ -101,6 +104,10 @@ When you change something about the database structure in the application we nee
 1. `python manage.py migrate`
 
 Note: If a change to the models was made that prevents the container from starting before the migrations are made, you can run this command in isolation: `docker-compose run web python manage.py makemigrations` and do the same to migrate.
+
+### Email Setup
+
+Email settings are defined in `settings.py`. To change the email address, change the `EMAIL_HOST_USER` and `EMAIL_HOST_PASSWORD` values (and other values if changing to a provider other than gmail). The email host password is defined in the .env file. To change to a new gmail account, ensure to use an app password and *not* the google account password.
 
 ### Testing
 


### PR DESCRIPTION
Email setup. I opted not to create another wrapper for the django send_mail method as it is already abstracted as much as we could need. For every instance where a notification should be sent, we will call the send_mail method.
As a proof of concept, I implemented an email notification for when an inspection is created or updated. To test this, you can create a client account with your real email, create an order, and have an employee inspect a sample from that order. You should receive an email immediately containing the inspection results.
This PR also includes a minor fix in the Order model method next_order_number() for new accounts creating orders.
Closes #275 